### PR TITLE
- Removed non-working laser autofocus blob from the makefile (fixes camera)

### DIFF
--- a/oneplus2/oneplus2-vendor-blobs.mk
+++ b/oneplus2/oneplus2-vendor-blobs.mk
@@ -120,7 +120,6 @@ PRODUCT_COPY_FILES += \
         vendor/oneplus/oneplus2/proprietary/lib/libril.so:/system/lib/libril.so \
         vendor/oneplus/oneplus2/proprietary/lib/librmnetctl.so:/system/lib/librmnetctl.so \
         vendor/oneplus/oneplus2/proprietary/lib64/hw/lights.msm8994.so:/system/lib64/hw/lights.msm8994.so \
-        vendor/oneplus/oneplus2/proprietary/lib64/hw/sensors.hal.tof.so:/system/lib64/hw/sensors.hal.tof.so \
         vendor/oneplus/oneplus2/proprietary/lib64/libcnefeatureconfig.so:/system/lib64/libcnefeatureconfig.so \
         vendor/oneplus/oneplus2/proprietary/lib64/libopcamera.so:/system/lib64/libopcamera.so \
         vendor/oneplus/oneplus2/proprietary/lib64/libopcameralib.so:/system/lib64/libopcameralib.so \


### PR DESCRIPTION
Currently sensors.hal.tof.so is added to the ROM on build. This breaks the camera since laser autofocus is just not working.
So it makes sense to remove it for the time being so that camera ate least work with traditional autofocus.
